### PR TITLE
Refactor grid cell class and add support for Tile Types

### DIFF
--- a/Map/Generator/MapGenerator.cs
+++ b/Map/Generator/MapGenerator.cs
@@ -9,12 +9,6 @@ namespace Roguelike.Map.Generator;
 public abstract partial class MapGenerator : Node
 {
 	
-	[Export] 
-	public int Width { get; set; }
-	
-	[Export] 
-	public int Height { get; set; }
-
 	[Signal]
 	public delegate void MapGeneratedEventHandler(GeneratorGrid grid);
 
@@ -24,11 +18,20 @@ public abstract partial class MapGenerator : Node
 	[Signal]
 	public delegate void MapFinalizedEventHandler(GeneratorGrid grid);
 	
-	public GeneratorGrid Grid;
+	public int Width { get; private set; }
 	
-	protected void EmitGenerated()
+	public int Height { get; private set; }
+
+	public TileTypeList TileTypes { get; private set; }
+
+
+	public GeneratorGrid Grid;
+
+	public MapGenerator(int width, int height)
 	{
-		EmitSignal(SignalName.MapGenerated, Grid);
+		Width = width;
+		Height = height;
+		TileTypes = new TileTypeList();
 	}
 	
 	public abstract void GenerateGrid();

--- a/Map/Generator/MapGenerator.cs
+++ b/Map/Generator/MapGenerator.cs
@@ -6,36 +6,72 @@ using Roguelike.Map.Model;
 
 namespace Roguelike.Map.Generator;
 
+/// <summary
 public abstract partial class MapGenerator : Node
 {
-	
+	/// <summary>
+	/// Delegate representing an event when a map is generated.
+	/// </summary>
+	/// <param name="grid">The generated grid for the map.</param>
 	[Signal]
 	public delegate void MapGeneratedEventHandler(GeneratorGrid grid);
 
+	/// <summary>
+	/// A delegate representing the event handler for when the map is updated. </summary> <param name="grid">The updated generator grid.</param>
+	/// /
 	[Signal]
 	public delegate void MapUpdatedEventHandler(GeneratorGrid grid);
 
+	/// <summary>
+	/// Delegate to handle the event when a map has been finalized.
+	/// </summary>
+	/// <param name="grid">The finalized generator grid.</param>
 	[Signal]
 	public delegate void MapFinalizedEventHandler(GeneratorGrid grid);
-	
+
+	/// <summary>
+	/// Gets the width of the Map being generated.
+	/// </summary>
+	/// <remarks>
+	/// The width value represents the width dimension of the map being generated, in 'sqaures'.
+	/// </remarks>
 	public int Width { get; private set; }
 	
+	/// <summary>
+	/// Gets the height of the Map being generated.
+	/// </summary>
+	/// <remarks>
+	/// The width value represents the height dimension of the map being generated, in 'sqaures'.
+	/// </remarks>
 	public int Height { get; private set; }
 
+	/// <summary>
+	/// Gets the list of available tile types used by this generator.
+	/// </summary>
 	public TileTypeList TileTypes { get; private set; }
 
-
+	/// <summary>
+	/// Represents a generator grid (the grid we'll be working with to abstract our procedural genration work).
+	/// </summary>
 	public GeneratorGrid Grid;
 
+	/// <summary
 	public MapGenerator(int width, int height)
 	{
 		Width = width;
 		Height = height;
 		TileTypes = new TileTypeList();
 	}
-	
+
+	/// <summary>
+	/// Generate the procedural grid.
+	/// </summary>
 	public abstract void GenerateGrid();
 
+	/// <summary>
+	/// Initializes the grid for the MapGenerator.
+	/// </summary>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if Width or Height is less than or equal to zero.</exception>
 	public void InitializeGrid()
 	{
 		if (Width > 0 && Height > 0)

--- a/Map/Generator/ProceduralTileMapGenerator.cs
+++ b/Map/Generator/ProceduralTileMapGenerator.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using Roguelike.Map.Generator;
@@ -24,6 +25,8 @@ public partial class ProceduralTileMapGenerator : Node
 	// Path to JSON file which describes the relationships between the Tiles found in a TileSet
 	// and their corresponding TileTypes, as provided by the MapGenerator.
 	public string TileAssociationsPath { get; set; }
+
+	public Dictionary<TileType, HashSet<TileAddress>> TileTypeAssignments { get; private set; }
 	
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
@@ -32,6 +35,8 @@ public partial class ProceduralTileMapGenerator : Node
 		ActiveMapGenerator.MapGenerated += OnMapGenerated;
 		ActiveMapGenerator.MapUpdated += OnMapUpdated;
 		ActiveMapGenerator.MapFinalized += OnMapFinalized;
+
+		TileTypeAssignments = new Dictionary<TileType, HashSet<TileAddress>>();
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Map/Generator/ProceduralTileMapGenerator.cs
+++ b/Map/Generator/ProceduralTileMapGenerator.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Roguelike.Map.Generator;
 using Roguelike.Map.Model;
 
+/// <summary
 public partial class ProceduralTileMapGenerator : Node
 {
 	[Export] 
@@ -26,6 +27,12 @@ public partial class ProceduralTileMapGenerator : Node
 	// and their corresponding TileTypes, as provided by the MapGenerator.
 	public string TileAssociationsPath { get; set; }
 
+	/// <summary>
+	/// Gets the dictionary that contains the tile type assignments.
+	/// </summary>
+	/// <value>
+	/// The dictionary that contains the tile type assignments.
+	/// </value>
 	public Dictionary<TileType, HashSet<TileAddress>> TileTypeAssignments { get; private set; }
 	
 	// Called when the node enters the scene tree for the first time.
@@ -44,6 +51,10 @@ public partial class ProceduralTileMapGenerator : Node
 	{
 	}
 
+	/// <summary>
+	/// This method is invoked when the node is about to be removed from the scene tree.
+	/// It is responsible for cleaning up any resources or event subscriptions.
+	/// </summary>
 	public override void _ExitTree()
 	{
 		// Remove Connects to ActiveMapGenerator Delegates. 

--- a/Map/Model/GridCell.cs
+++ b/Map/Model/GridCell.cs
@@ -4,18 +4,24 @@ using Godot.Collections;
 
 namespace Roguelike.Map.Model;
 
+/// <summary
 public partial class GridCell : GodotObject
 {
 	/// <summary>
 	/// Gets or sets a value indicating whether the object is active or not.
 	/// </summary>
-	public bool IsActive { get; set; }
+	public bool IsActive { get; private set; }
+	
+	/// <summary>
+	/// Gets or sets the type of the tile.
+	/// </summary>
+	public TileType Type { get; private set; }
 
 	/// <summary>
 	/// Gets or sets the position of an object.
 	/// </summary>
-	public Vector2I Position { get; set; }
-
+	public Vector2I Position { get; private set; }
+	
 	/// <summary>
 	/// Gets or sets the data associated with the property.
 	/// </summary>
@@ -29,9 +35,36 @@ public partial class GridCell : GodotObject
 	/// </summary>
 	public GridCell(int x = 0, int y = 0)
 	{
-		Position = new Vector2I(x, y);
+		var position = new Vector2I(x, y);
+		InitializeGridCell(position);
+	}
+	
+	/// <summary>
+	/// Represents a cell in a grid.
+	/// </summary>
+	/// <param name="position">The position of the cell in the grid.</param>
+	public GridCell(Vector2I position)
+	{
+		InitializeGridCell(position);
+	}
+
+	/// <summary>
+	/// Activates the specified tile with the given type.
+	/// </summary>
+	/// <param name="type">The type of the tile to activate.</param>
+	public void Activate(TileType type)
+	{
+		IsActive = true;
+		Type = type;
+	}
+
+	/// <summary>
+	/// Deactivates the object.
+	/// </summary>
+	public void Deactivate()
+	{
 		IsActive = false;
-		Data = new Dictionary<string, string>();
+		Type = null;
 	}
 
 	/// <summary>
@@ -59,11 +92,13 @@ public partial class GridCell : GodotObject
 	}
 
 	/// <summary>
-	/// Represents a cell in a grid.
+	/// Initializes a grid cell with the given position.
 	/// </summary>
-	/// <param name="position">The position of the cell in the grid.</param>
-	public GridCell(Vector2I position)
+	/// <param name="position">The position of the grid cell.</param>
+	private void InitializeGridCell(Vector2I position)
 	{
 		Position = position;
+		IsActive = false;
+		Data = new Dictionary<string, string>();	
 	}
 }

--- a/Map/Model/TileAddress.cs
+++ b/Map/Model/TileAddress.cs
@@ -5,6 +5,12 @@ namespace Roguelike.Map.Model;
 
 public class TileAddress : Tuple<int, Vector2I>
 {
+    /// <summary>
+    /// Gets the AtlasId of the tile.
+    /// </summary>
+    /// <remarks>
+    /// This property returns the AtlasId associated with the tile.
+    /// </remarks>
     public int AtlasId
     {
         get
@@ -13,6 +19,12 @@ public class TileAddress : Tuple<int, Vector2I>
         }
     }
 
+    /// <summary>
+    /// Gets the position of the tile.
+    /// </summary>
+    /// <value>
+    /// The position of the object within the TileSet's Atlas.
+    /// </value>
     public Vector2I Position
     {
         get
@@ -20,7 +32,12 @@ public class TileAddress : Tuple<int, Vector2I>
             return Item2;
         }
     }
-    
+
+    /// <summary>
+    /// Represents a tile address with an atlas ID and its position on the Atlas's 2D grid.
+    /// </summary>
+    /// <param name="atlasId">The ID of the atlas that the tile belongs to.</param>
+    /// <param name="position">The position of the tile in 2D space.</param>
     public TileAddress(int atlasId, Vector2I position) : base(atlasId, position)
     {
     }

--- a/Map/Model/TileAddress.cs
+++ b/Map/Model/TileAddress.cs
@@ -1,0 +1,27 @@
+using System;
+using Godot;
+
+namespace Roguelike.Map.Model;
+
+public class TileAddress : Tuple<int, Vector2I>
+{
+    public int AtlasId
+    {
+        get
+        {
+            return Item1;
+        }
+    }
+
+    public Vector2I Position
+    {
+        get
+        {
+            return Item2;
+        }
+    }
+    
+    public TileAddress(int atlasId, Vector2I position) : base(atlasId, position)
+    {
+    }
+}

--- a/Map/Model/TileType.cs
+++ b/Map/Model/TileType.cs
@@ -4,9 +4,19 @@ using System.Collections.Generic;
 
 public partial class TileType : GodotObject, IEquatable<TileType>
 {
+    /// <summary>
+    /// Gets or sets the name.
+    /// </summary>
     public string Name { get; set; }
+
+    /// <summary>
+    /// Represents a dictionary containing key-value pairs of strings.
+    /// </summary>
     public Dictionary<string, string> Data;
 
+    /// <summary>
+    /// Represents a tile type.
+    /// </summary>
     public TileType()
     {
         Data = new Dictionary<string, string>();

--- a/Map/Model/TileType.cs
+++ b/Map/Model/TileType.cs
@@ -1,0 +1,48 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+public partial class TileType : GodotObject, IEquatable<TileType>
+{
+    public string Name { get; set; }
+    public Dictionary<string, string> Data;
+
+    public TileType()
+    {
+        Data = new Dictionary<string, string>();
+    }
+    
+    /// <summary>
+    /// Represents an indexer that allows accessing elements of the cell's data dictionary using property names as keys.
+    /// </summary>
+    /// <param name="propertyName">The property name used as the key to access the value in the dictionary.</param>
+    /// <returns>The value associated with the specified property name.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the property with the specified key is not found in the dictionary.</exception>
+    public string this[string propertyName]
+    {
+        get
+        {
+            if (Data.ContainsKey(propertyName))
+            {
+                return Data[propertyName];
+            }
+
+            throw new InvalidOperationException($"Property with key '{propertyName}' not found.");
+        }
+
+        set 
+        {
+            Data[propertyName] = value;
+        }
+    }
+
+    public bool Equals(TileType other)
+    {
+        if (other != null && other.Name == Name)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Map/Model/TileTypeList.cs
+++ b/Map/Model/TileTypeList.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Roguelike.Map.Model;
+
+public class TileTypeList : List<TileType>
+{
+    public TileType FindByName(string name)
+    {
+        return this.Find(type => type.Name == name);
+    }
+}

--- a/Map/Model/TileTypeList.cs
+++ b/Map/Model/TileTypeList.cs
@@ -4,6 +4,11 @@ namespace Roguelike.Map.Model;
 
 public class TileTypeList : List<TileType>
 {
+    /// <summary>
+    /// Finds a TileType by its name.
+    /// </summary>
+    /// <param name="name">The name of the TileType to find.</param>
+    /// <returns>The TileType with the specified name, or null if not found.</returns>
     public TileType FindByName(string name)
     {
         return this.Find(type => type.Name == name);

--- a/Roguelike.csproj
+++ b/Roguelike.csproj
@@ -5,7 +5,4 @@
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'ios' ">net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
-  <ItemGroup>
-    <Folder Include="Map\Model\" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Details:
- Refactored GridCell class to encapsulate object state and ensure only valid state transitions.
- Introduced concepts of TileType and TileAddress in Map Model.
- Tile address class defined with AtlasId and Position properties.  Reflects address of a tile within Godot TileSet.
- Added TileType class with properties for Name and Data.
- Implemented Equals method in TileType class for identification purposes.
- Added new class TileTypeList for simplified TileType referencing capabilities.
- Updated MapGenerator class.  Added TileTypes properties so it can declare its TileTypes to the system.  Took Width and Height out of the Exposed category.  Added instead to the class constructor.
- Added private property TileTypeAssignments to ProceduralTileMapGenerator.