### PR TITLE
26 sequential map processing

### DIFF
--- a/Map/Generator/CellularAutomataMapGenerator.cs
+++ b/Map/Generator/CellularAutomataMapGenerator.cs
@@ -31,18 +31,12 @@ public partial class CellularAutomataMapGenerator : Roguelike.Map.Generator.MapG
 		TileTypes.Add(new Model.TileType { Name=TileType_Floor } );
 	}
 
-	public override void _Ready()
-	{
-		base._Ready();
-		GenerateGrid();
-	}
 
 	/// <summary>
 	/// Generates a grid for the map.
 	/// </summary>
-	public override void GenerateGrid()
+	public override void Begin()
 	{
-		InitializeGrid();
 		var numberOfStartPoints = HowManyStartPoints();
 		GenerateStartPoints(numberOfStartPoints);
 		var active = Grid.QueryActiveCells();

--- a/Map/Generator/MapGenerator.cs
+++ b/Map/Generator/MapGenerator.cs
@@ -30,18 +30,16 @@ public abstract partial class MapGenerator : Godot.Node
 	/// Gets the width of the Map being generated.
 	/// </summary>
 	/// <remarks>
-	/// The width value represents the width dimension of the map being generated, in 'sqaures'.
+	/// The width value represents the width dimension of the map being mainpulated, in 'squares.' 
 	/// </remarks>
-	[Export]
 	public int Width { get; private set; }
 	
 	/// <summary>
 	/// Gets the height of the Map being generated.
 	/// </summary>
 	/// <remarks>
-	/// The width value represents the height dimension of the map being generated, in 'sqaures'.
+	/// The width value represents the height dimension of the map being manipulated, in 'sqaures.' 
 	/// </remarks>
-	[Export]
 	public int Height { get; private set; }
 
 	/// <summary>
@@ -49,12 +47,21 @@ public abstract partial class MapGenerator : Godot.Node
 	/// </summary>
 	public TileTypeList TileTypes { get; private set; }
 
+	private GeneratorGrid _grid;
 	/// <summary>
 	/// Represents a generator grid (the grid we'll be working with to abstract our procedural genration work).
 	/// </summary>
-	public Model.GeneratorGrid Grid;
+	public Model.GeneratorGrid Grid
+	{
+		get { return _grid; }
+		set
+		{
+			_grid = value;
+			Width = _grid.Size.X;
+			Height = _grid.Size.Y;
+		}
+	}
 
-	/// <summary
 	public MapGenerator()
 	{
 		TileTypes = new TileTypeList();
@@ -63,22 +70,5 @@ public abstract partial class MapGenerator : Godot.Node
 	/// <summary>
 	/// Generate the procedural grid.
 	/// </summary>
-	public abstract void GenerateGrid();
-
-	/// <summary>
-	/// Initializes the grid for the MapGenerator.
-	/// </summary>
-	/// <exception cref="ArgumentOutOfRangeException">Thrown if Width or Height is less than or equal to zero.</exception>
-	public void InitializeGrid()
-	{
-		if (Width > 0 && Height > 0)
-		{
-			Grid = new Model.GeneratorGrid(new Vector2I(Width, Height));
-		}
-		else
-		{
-			throw new ArgumentOutOfRangeException("Width and Height must be set before initializing " +
-												  "MapGenerator's Generator Grid.");
-		}
-	}
+	public abstract void Begin();
 }

--- a/Map/Generator/MapGenerator.cs
+++ b/Map/Generator/MapGenerator.cs
@@ -57,8 +57,12 @@ public abstract partial class MapGenerator : Godot.Node
 		set
 		{
 			_grid = value;
-			Width = _grid.Size.X;
-			Height = _grid.Size.Y;
+
+			if (_grid != null)
+			{
+				Width = _grid.Size.X;
+				Height = _grid.Size.Y;
+			}
 		}
 	}
 

--- a/Map/Generator/Room/BasicRoomPlacementGenerator.cs
+++ b/Map/Generator/Room/BasicRoomPlacementGenerator.cs
@@ -21,14 +21,13 @@ public partial class BasicRoomPlacementGenerator : RoomGenerator
 		RoomSizeMax = Math.Max(3, RoomSizeMax);
 		RoomCountMin = Math.Max(1, RoomCountMin);
 		RoomCountMax = Math.Max(1, RoomCountMax);
-		GenerateGrid();
 	}
 
 	/// <summary>
 	/// Generates a grid for room generation.
 	/// </summary>
 	/// <exception cref="ArgumentException">Thrown when the maximum room size is less than the minimum room size or when the maximum room count is less than the minimum room count.</exception>
-	public override void GenerateGrid()
+	public override void Begin()
 	{
 		if (RoomSizeMax < RoomSizeMin)
 		{
@@ -40,7 +39,6 @@ public partial class BasicRoomPlacementGenerator : RoomGenerator
 			throw new ArgumentException("RoomCountMax cannot be less than RoomCountMin");
 		}
 		
-		InitializeGrid();
 		GD.Randomize();
 		Generate();
 	}

--- a/Map/Generator/Room/BinarySpacePartitionGenerator.cs
+++ b/Map/Generator/Room/BinarySpacePartitionGenerator.cs
@@ -21,12 +21,10 @@ public partial class BinarySpacePartitionGenerator : RoomGenerator
 		DivisionDepth = Math.Max(1, DivisionDepth);
 		MinConnectionsPerRoom = Math.Max(1, MinConnectionsPerRoom);
 		MaxConnectionsPerRoom = Math.Max(1, MaxConnectionsPerRoom);
-		GenerateGrid();
 	}
 	
-	public override void GenerateGrid()
+	public override void Begin()
 	{
-		InitializeGrid();
 		GD.Randomize();
 		Generate();
 	}

--- a/Map/Generator/Room/InformalBinarySpacePartitionGenerator.cs
+++ b/Map/Generator/Room/InformalBinarySpacePartitionGenerator.cs
@@ -15,17 +15,15 @@ public partial class InformalBinarySpacePartitionGenerator : RoomGenerator
 		base._Ready();
 		RoomCountMin = Math.Max(1, RoomCountMin);
 		RoomCountMax = Math.Max(1, RoomCountMax);
-		GenerateGrid();
 	}
 
-	public override void GenerateGrid()
+	public override void Begin()
 	{
 		if (RoomCountMax < RoomCountMin)
 		{
 			throw new ArgumentException("RoomCountMax cannot be less than RoomCountMin");
 		}
 		
-		InitializeGrid();
 		GD.Randomize();
 		Generate();
 	}

--- a/Map/Generator/Room/RoomGenerator.cs
+++ b/Map/Generator/Room/RoomGenerator.cs
@@ -22,9 +22,8 @@ public abstract partial class RoomGenerator : MapGenerator
 		TileTypes.Add(new TileType { Name=TileType_Floor } );
 	}
 
-	public override void GenerateGrid()
+	public override void Begin()
 	{
-		InitializeGrid();
 		GD.Randomize();
 		Generate();
 	}

--- a/Map/ProceduralMapBuilder.cs
+++ b/Map/ProceduralMapBuilder.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Godot;
 using Godot.Collections;
 using Roguelike.Map.Model;
+using Roguelike.Map.Render;
 using FileAccess = Godot.FileAccess;
 
 namespace Roguelike.Map.Generator;
@@ -44,15 +45,9 @@ public partial class ProceduralMapBuilder : Node
 	// will be used to build the map.
 	public Roguelike.Map.Generator.MapGenerator ActiveMapGenerator { get; private set; }
 	private int _activeMapGeneratorIndex = 0;
-
-	/// <summary>
-	/// Gets the dictionary that contains the tile type assignments.
-	/// </summary>
-	/// <value>
-	/// The dictionary that contains the tile type assignments.
-	/// </value>
-	public System.Collections.Generic.Dictionary<Model.TileType, HashSet<TileAddress>> TileTypeAssignments { get; private set; }
+	private GridRenderer _gridRenderer;
 	
+
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
@@ -61,15 +56,13 @@ public partial class ProceduralMapBuilder : Node
 			throw new InvalidOperationException("MapGeneratorQueue must have at least one element.");
 		}
 
+		_gridRenderer = new GridRenderer(MapGeneratorSequence, SourceTileSet, TileAssociationsPath);
 		ResetGrid();
 
 		ActiveMapGenerator = MapGeneratorSequence[_activeMapGeneratorIndex];
 		ConnectActiveMapGenerator();
 
-		TileTypeAssignments = new System.Collections.Generic.Dictionary<Model.TileType, HashSet<TileAddress>>();
 		ActiveTileMap.TileSet = SourceTileSet;
-
-		ReadTileAssociations();
 		ActiveMapGenerator.Begin();
 	}
 	
@@ -97,16 +90,16 @@ public partial class ProceduralMapBuilder : Node
 	/// from MapGenerator instance.
 	/// </summary>
 	/// <param name="grid">The generated grid.</param>
-	private void OnMapGenerated(Model.GeneratorGrid grid)
+	private void OnMapGenerated(GeneratorGrid grid)
 	{
-		RenderGrid(grid);
+		_gridRenderer.RenderGrid(grid, ActiveTileMap);
 	}
 
 	/// <summary>
 	/// Handles the event when the map is updated.  May be signalled multiple times.
 	/// </summary>
 	/// <param name="grid">The updated generator grid.</param>
-	private void OnMapUpdated(Model.GeneratorGrid grid)
+	private void OnMapUpdated(GeneratorGrid grid)
 	{
 		OnMapGenerated(grid);
 	}
@@ -170,177 +163,5 @@ public partial class ProceduralMapBuilder : Node
 			throw new ArgumentOutOfRangeException("Width and Height must be set before initializing " +
 												  "MapGenerator's Generator Grid.");
 		}
-	}
-
-
-	/// <summary>
-	/// Renders the given generator grid by assigning tiles to grid cells based on their type.
-	/// </summary>
-	/// <param name="grid">The generator grid to render.</param>
-	/// <exception cref="InvalidOperationException">
-	/// Thrown if the type of a grid cell is not found in the TileTypeAssignments dictionary.
-	/// Thrown if no tiles are available for a grid cell's tile type in the TileTypeAssignments dictionary.
-	/// </exception>
-	private void RenderGrid(GeneratorGrid grid)
-	{
-		TileType currentTileType;
-		HashSet<TileAddress> currentTilesAvailable;
-		for (int x = 0; x < grid.Size.X ; x++)
-		{
-			for (int y = 0; y < grid.Size.Y; y++)
-			{
-				GridCell cell = grid.GridCells[x, y];
-
-				if (!cell.IsActive)
-				{
-					ActiveTileMap.EraseCell(0, new Vector2I(x,y));
-					continue;
-				}
-				
-				currentTileType = grid.GridCells[x, y].Type;
-				if (currentTileType == null)
-				{
-					throw new InvalidOperationException("Type (TileType) not found on Grid Cell [" + x.ToString() +
-														"," + y.ToString() + "]");
-				}
-				
-				currentTilesAvailable = TileTypeAssignments[currentTileType];
-				if (currentTilesAvailable == null)
-				{
-					throw new InvalidOperationException("Invalid TileType on Type property of Grid Cell [" + x.ToString() + "," + y.ToString() + "]");
-				}
-
-				int tileListLength = currentTilesAvailable.Count;
-				if (tileListLength == 0)
-				{
-					throw new InvalidOperationException("No TileSet tiles are avilable for TileType " + currentTileType.Name);
-				}
-				int randomIndex = new Random().Next(tileListLength);
-				TileAddress randomTile = currentTilesAvailable.ElementAt(randomIndex);
-				
-				ActiveTileMap.SetCell(0, new Vector2I( x, y ), randomTile.AtlasId, randomTile.Position );	
-			}	
-		}	
-	}
-
-	/// <summary>
-	/// @stub
-	/// Reads tile associations from a JSON file.
-	/// </summary>
-	private void ReadTileAssociations()
-	{
-		if (ActiveMapGenerator == null || SourceTileSet == null || string.IsNullOrEmpty(TileAssociationsPath))
-		{
-			throw new InvalidOperationException(
-				"The active map generator, source tileset, or tile associations path is missing.");
-		}
-
-		Json json = loadAndExtractAssociationJson();
-		
-		var data = json.Data;
-		Godot.Collections.Dictionary dictionary = data.AsGodotDictionary();
-		ValidateTopLevelAssociationJsonFile(dictionary);
-		
-		Godot.Collections.Array tileTypeAssociations = dictionary["tiletype_associations"].AsGodotArray();
-		
-		for (int i = 0; i < tileTypeAssociations.Count ; i++)
-		{
-			Godot.Collections.Dictionary tileTypeAssociation = tileTypeAssociations[i].AsGodotDictionary();
-			ValidateAssociationStructureInJsonFile(tileTypeAssociation) ;
-			
-			string tileTypeName = tileTypeAssociation["tiletype"].AsString();
-			TileType tileType = ActiveMapGenerator.TileTypes.FindByName(tileTypeName);
-			VerifyJsonIsRequestingValidTileType(tileTypeName, tileType);
-
-			Godot.Collections.Array tileAddressArray = tileTypeAssociation["association"].AsGodotArray();
-
-			for (int j = 0; j < tileAddressArray.Count; j++)
-			{
-				Godot.Collections.Dictionary tileAddressDictionary = tileAddressArray[j].AsGodotDictionary();
-				ValidateTileAddressJson(tileAddressDictionary);
-
-				TileAddress tileAddress = new TileAddress(
-					tileAddressDictionary["atlasId"].AsInt32(),
-					tileAddressDictionary["atlasX"].AsInt32(),
-					tileAddressDictionary["atlasY"].AsInt32()
-				);
-
-				if (!TileTypeAssignments.ContainsKey(tileType))
-				{
-					TileTypeAssignments.Add(tileType, new HashSet<TileAddress>());
-				}
-
-				HashSet<TileAddress> writeToHashSet;
-				TileTypeAssignments.TryGetValue(tileType, out writeToHashSet);
-				writeToHashSet.Add(tileAddress);
-			}
-		}
-	}
-
-	private Json loadAndExtractAssociationJson()
-	{
-		Json json = new Json();
-		Godot.FileAccess file = FileAccess.Open(TileAssociationsPath, FileAccess.ModeFlags.Read);
-		if (file == null)
-		{
-			throw new FileNotFoundException("The specified json file could not be found or loaded.", TileAssociationsPath);	
-		}
-		Godot.Error error = json.Parse(file.GetAsText());
-		file.Close();
-
-		if (error != Godot.Error.Ok)
-		{
-			throw new IOException("An error occurred while parsing the json file.");	
-		}
-
-		return json;
-	}
-	
-	private void ValidateTopLevelAssociationJsonFile(Godot.Collections.Dictionary dictionary)
-	{
-		if (!dictionary.ContainsKey("tiletype_associations"))
-		{
-			throw new InvalidOperationException("Required key 'tiletype_associations' is missing from the source json file");
-		}	
-	}
-
-	private void ValidateAssociationStructureInJsonFile(Godot.Collections.Dictionary dictionary)
-	{
-		// Check for required property names
-		if (!dictionary.ContainsKey("tiletype"))
-		{
-			throw new InvalidOperationException("Required key 'tiletype' is missing from the source json file");
-		}
-
-		if (!dictionary.ContainsKey("association"))
-		{
-			throw new InvalidOperationException("Required key 'association' is missing from the source json file");
-		}	
-	}
-
-	private void VerifyJsonIsRequestingValidTileType(string tileTypeName, TileType tileType)
-	{
-		if (tileType == null)
-		{
-			throw new InvalidOperationException("TileType '" + tileTypeName +
-												"' was specified in source json, but does not exist on ActiveMapGenerator.");
-		}	
-	}
-
-	private void ValidateTileAddressJson(Godot.Collections.Dictionary dictionary)
-	{
-		// Throw error if required keys not found
-		if (!dictionary.ContainsKey("atlasId"))
-		{
-			throw new InvalidOperationException("Required key 'atlasId' is missing from the source json file");
-		}
-		if (!dictionary.ContainsKey("atlasX"))
-		{
-			throw new InvalidOperationException("Required key 'atlasX' is missing from the source json file");
-		}
-		if (!dictionary.ContainsKey("atlasY"))
-		{
-			throw new InvalidOperationException("Required key 'atlasY' is missing from the source json file");
-		}	
 	}
 }

--- a/Map/ProceduralMapBuilder.cs
+++ b/Map/ProceduralMapBuilder.cs
@@ -123,7 +123,7 @@ public partial class ProceduralMapBuilder : Node
 		DisconnectActiveMapGenerator();
 		if (_activeMapGeneratorIndex + 1 < MapGeneratorSequence.Count)
 		{
-			ActiveMapGenerator = MapGeneratorSequence[_activeMapGeneratorIndex];
+			ActiveMapGenerator = MapGeneratorSequence[++_activeMapGeneratorIndex];
 			ConnectActiveMapGenerator();
 			return true;
 		}

--- a/Map/ProceduralMapBuilder.cs
+++ b/Map/ProceduralMapBuilder.cs
@@ -23,9 +23,25 @@ public partial class ProceduralMapBuilder : Node
 	// The TileSet from which tiles will be extracted and applied to the TileMap
 	public TileSet SourceTileSet { get; set; }
 
+	/// <summary>
+	/// Gets or sets the width of the generated map.
+	/// </summary>
+	/// <remarks>
+	/// The generated map width determines the horizontal size of the map that is being generated.
+	/// </remarks>
+	/// <value>
+	/// The width of the generated map.
+	/// </value>
 	[Export]
 	public int GeneratedMapWidth { get; set; }
-	
+
+	/// <summary>
+	/// Gets or sets the height of the generated map.
+	/// </summary>
+	/// <remarks>
+	/// This property represents the height of the generated map.
+	/// The value of this property is used to determine the vertical size of the generated map.
+	/// </remarks>
 	[Export]
 	public int GeneratedMapHeight { get; set; }
 
@@ -43,7 +59,7 @@ public partial class ProceduralMapBuilder : Node
 	
 	// The Map Generator Instance which is responsible for providing the procedural genration algorithm which
 	// will be used to build the map.
-	public Roguelike.Map.Generator.MapGenerator ActiveMapGenerator { get; private set; }
+	public MapGenerator ActiveMapGenerator { get; private set; }
 	private int _activeMapGeneratorIndex = 0;
 	private GridRenderer _gridRenderer;
 	
@@ -56,16 +72,26 @@ public partial class ProceduralMapBuilder : Node
 			throw new InvalidOperationException("MapGeneratorQueue must have at least one element.");
 		}
 
-		_gridRenderer = new GridRenderer(MapGeneratorSequence, SourceTileSet, TileAssociationsPath);
+		// Initialize the Grid Renderer.
+		_gridRenderer = new GridRenderer(MapGeneratorSequence, TileAssociationsPath);
+		
+		// Reset (Initialize) the GeneratorGrid.
 		ResetGrid();
 
+		// Set the 0th ActiveMapGenerator in the MapGeneratorSequence array.  Connect it to the system.
 		ActiveMapGenerator = MapGeneratorSequence[_activeMapGeneratorIndex];
 		ConnectActiveMapGenerator();
 
+		// Assign the given TileSet to the ActiveTileMap.  
 		ActiveTileMap.TileSet = SourceTileSet;
+		
+		// Start work on the first generator (Subsequent generators will be invoked on the OnMapFinalized callback).
 		ActiveMapGenerator.Begin();
 	}
 	
+	/// <summary>
+	/// Reinitialize the Grid, clearing out any contents.
+	/// </summary>
 	public void ResetGrid()
 	{
 		Grid = InitializeGrid();

--- a/Map/Render/GridRenderer.cs
+++ b/Map/Render/GridRenderer.cs
@@ -1,0 +1,209 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Godot.Collections;
+using Roguelike.Map.Generator;
+using Roguelike.Map.Model;
+using FileAccess = Godot.FileAccess;
+
+namespace Roguelike.Map.Render;
+
+public partial class GridRenderer : Node
+{
+	/// <summary>
+	/// Gets the dictionary that contains the tile type assignments.
+	/// </summary>
+	/// <value>
+	/// The dictionary that contains the tile type assignments.
+	/// </value>
+	public System.Collections.Generic.Dictionary<TileType, HashSet<TileAddress>> TileTypeAssignments { get; private set; }
+	
+	/// <summary>
+	/// @stub
+	/// Reads tile associations from a JSON file.
+	/// </summary>
+	public GridRenderer(Array<MapGenerator> mapGenerators, TileSet sourceTileSet, string tileAssociationsPath )
+	{
+		if (mapGenerators.Count == 0 || sourceTileSet == null || string.IsNullOrEmpty(tileAssociationsPath))
+		{
+			throw new InvalidOperationException(
+				"The active map generator, source tileset, or tile associations path is missing.");
+		}
+
+		TileTypeAssignments = new System.Collections.Generic.Dictionary<TileType, HashSet<TileAddress>>();
+
+		Json json = loadAndExtractAssociationJson(tileAssociationsPath);
+		
+		var data = json.Data;
+		Godot.Collections.Dictionary dictionary = data.AsGodotDictionary();
+		ValidateTopLevelAssociationJsonFile(dictionary);
+		
+		Godot.Collections.Array tileTypeAssociations = dictionary["tiletype_associations"].AsGodotArray();
+
+		// Group up all tile types for validation.
+		TileTypeList allTileTypes = new TileTypeList();
+		foreach (MapGenerator generator in mapGenerators)
+		{
+			foreach (TileType tiletype in generator.TileTypes)
+			{
+				if (!allTileTypes.Contains(tiletype))
+				{
+					allTileTypes.Add(tiletype);
+				}
+			}
+		}
+		
+		for (int i = 0; i < tileTypeAssociations.Count ; i++)
+		{
+			Godot.Collections.Dictionary tileTypeAssociation = tileTypeAssociations[i].AsGodotDictionary();
+			ValidateAssociationStructureInJsonFile(tileTypeAssociation) ;
+			
+			string tileTypeName = tileTypeAssociation["tiletype"].AsString();
+			TileType tileType = allTileTypes.FindByName(tileTypeName);
+			VerifyJsonIsRequestingValidTileType(tileTypeName, tileType);
+
+			Godot.Collections.Array tileAddressArray = tileTypeAssociation["association"].AsGodotArray();
+
+			for (int j = 0; j < tileAddressArray.Count; j++)
+			{
+				Godot.Collections.Dictionary tileAddressDictionary = tileAddressArray[j].AsGodotDictionary();
+				ValidateTileAddressJson(tileAddressDictionary);
+
+				TileAddress tileAddress = new TileAddress(
+					tileAddressDictionary["atlasId"].AsInt32(),
+					tileAddressDictionary["atlasX"].AsInt32(),
+					tileAddressDictionary["atlasY"].AsInt32()
+				);
+
+				if (!TileTypeAssignments.ContainsKey(tileType))
+				{
+					TileTypeAssignments.Add(tileType, new HashSet<TileAddress>());
+				}
+
+				HashSet<TileAddress> writeToHashSet;
+				TileTypeAssignments.TryGetValue(tileType, out writeToHashSet);
+				writeToHashSet.Add(tileAddress);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Renders the given generator grid by assigning tiles to grid cells based on their type.
+	/// </summary>
+	/// <param name="grid">The generator grid to render.</param>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown if the type of a grid cell is not found in the TileTypeAssignments dictionary.
+	/// Thrown if no tiles are available for a grid cell's tile type in the TileTypeAssignments dictionary.
+	/// </exception>
+	public void RenderGrid(GeneratorGrid grid, TileMap ActiveTileMap)
+	{
+		TileType currentTileType;
+		HashSet<TileAddress> currentTilesAvailable;
+		for (int x = 0; x < grid.Size.X ; x++)
+		{
+			for (int y = 0; y < grid.Size.Y; y++)
+			{
+				GridCell cell = grid.GridCells[x, y];
+
+				if (!cell.IsActive)
+				{
+					ActiveTileMap.EraseCell(0, new Vector2I(x,y));
+					continue;
+				}
+				
+				currentTileType = grid.GridCells[x, y].Type;
+				if (currentTileType == null)
+				{
+					throw new InvalidOperationException("Type (TileType) not found on Grid Cell [" + x.ToString() +
+														"," + y.ToString() + "]");
+				}
+				
+				currentTilesAvailable = TileTypeAssignments[currentTileType];
+				if (currentTilesAvailable == null)
+				{
+					throw new InvalidOperationException("Invalid TileType on Type property of Grid Cell [" + x.ToString() + "," + y.ToString() + "]");
+				}
+
+				int tileListLength = currentTilesAvailable.Count;
+				if (tileListLength == 0)
+				{
+					throw new InvalidOperationException("No TileSet tiles are avilable for TileType " + currentTileType.Name);
+				}
+				int randomIndex = new Random().Next(tileListLength);
+				TileAddress randomTile = currentTilesAvailable.ElementAt(randomIndex);
+				
+				ActiveTileMap.SetCell(0, new Vector2I( x, y ), randomTile.AtlasId, randomTile.Position );	
+			}	
+		}	
+	}
+
+
+	private Json loadAndExtractAssociationJson(string tileAssociationsPath)
+	{
+		Json json = new Json();
+		Godot.FileAccess file = FileAccess.Open(tileAssociationsPath, FileAccess.ModeFlags.Read);
+		if (file == null)
+		{
+			throw new FileNotFoundException("The specified json file could not be found or loaded.", tileAssociationsPath);	
+		}
+		Godot.Error error = json.Parse(file.GetAsText());
+		file.Close();
+
+		if (error != Godot.Error.Ok)
+		{
+			throw new IOException("An error occurred while parsing the json file.");	
+		}
+
+		return json;
+	}
+	
+	private void ValidateTopLevelAssociationJsonFile(Dictionary dictionary)
+	{
+		if (!dictionary.ContainsKey("tiletype_associations"))
+		{
+			throw new InvalidOperationException("Required key 'tiletype_associations' is missing from the source json file");
+		}	
+	}
+
+	private void ValidateAssociationStructureInJsonFile(Dictionary dictionary)
+	{
+		// Check for required property names
+		if (!dictionary.ContainsKey("tiletype"))
+		{
+			throw new InvalidOperationException("Required key 'tiletype' is missing from the source json file");
+		}
+
+		if (!dictionary.ContainsKey("association"))
+		{
+			throw new InvalidOperationException("Required key 'association' is missing from the source json file");
+		}	
+	}
+
+	private void VerifyJsonIsRequestingValidTileType(string tileTypeName, TileType tileType)
+	{
+		if (tileType == null)
+		{
+			throw new InvalidOperationException("TileType '" + tileTypeName +
+												"' was specified in source json, but does not exist on ActiveMapGenerator.");
+		}	
+	}
+
+	private void ValidateTileAddressJson(Dictionary dictionary)
+	{
+		// Throw error if required keys not found
+		if (!dictionary.ContainsKey("atlasId"))
+		{
+			throw new InvalidOperationException("Required key 'atlasId' is missing from the source json file");
+		}
+		if (!dictionary.ContainsKey("atlasX"))
+		{
+			throw new InvalidOperationException("Required key 'atlasX' is missing from the source json file");
+		}
+		if (!dictionary.ContainsKey("atlasY"))
+		{
+			throw new InvalidOperationException("Required key 'atlasY' is missing from the source json file");
+		}	
+	}
+}

--- a/Map/Render/GridRenderer.cs
+++ b/Map/Render/GridRenderer.cs
@@ -24,9 +24,9 @@ public partial class GridRenderer : Node
 	/// @stub
 	/// Reads tile associations from a JSON file.
 	/// </summary>
-	public GridRenderer(Array<MapGenerator> mapGenerators, TileSet sourceTileSet, string tileAssociationsPath )
+	public GridRenderer(Array<MapGenerator> mapGenerators, string tileAssociationsPath )
 	{
-		if (mapGenerators.Count == 0 || sourceTileSet == null || string.IsNullOrEmpty(tileAssociationsPath))
+		if (mapGenerators.Count == 0 || string.IsNullOrEmpty(tileAssociationsPath))
 		{
 			throw new InvalidOperationException(
 				"The active map generator, source tileset, or tile associations path is missing.");

--- a/Map/Render/GridRenderer.cs
+++ b/Map/Render/GridRenderer.cs
@@ -18,7 +18,7 @@ public partial class GridRenderer : Node
 	/// <value>
 	/// The dictionary that contains the tile type assignments.
 	/// </value>
-	public System.Collections.Generic.Dictionary<TileType, HashSet<TileAddress>> TileTypeAssignments { get; private set; }
+	public System.Collections.Generic.Dictionary<string, HashSet<TileAddress>> TileTypeAssignments { get; private set; }
 	
 	/// <summary>
 	/// @stub
@@ -32,7 +32,7 @@ public partial class GridRenderer : Node
 				"The active map generator, source tileset, or tile associations path is missing.");
 		}
 
-		TileTypeAssignments = new System.Collections.Generic.Dictionary<TileType, HashSet<TileAddress>>();
+		TileTypeAssignments = new System.Collections.Generic.Dictionary<string, HashSet<TileAddress>>();
 
 		Json json = loadAndExtractAssociationJson(tileAssociationsPath);
 		
@@ -57,7 +57,7 @@ public partial class GridRenderer : Node
 		
 		for (int i = 0; i < tileTypeAssociations.Count ; i++)
 		{
-			Godot.Collections.Dictionary tileTypeAssociation = tileTypeAssociations[i].AsGodotDictionary();
+			Dictionary tileTypeAssociation = tileTypeAssociations[i].AsGodotDictionary();
 			ValidateAssociationStructureInJsonFile(tileTypeAssociation) ;
 			
 			string tileTypeName = tileTypeAssociation["tiletype"].AsString();
@@ -77,13 +77,13 @@ public partial class GridRenderer : Node
 					tileAddressDictionary["atlasY"].AsInt32()
 				);
 
-				if (!TileTypeAssignments.ContainsKey(tileType))
+				if (!TileTypeAssignments.ContainsKey(tileType.Name))
 				{
-					TileTypeAssignments.Add(tileType, new HashSet<TileAddress>());
+					TileTypeAssignments.Add(tileType.Name, new HashSet<TileAddress>());
 				}
 
 				HashSet<TileAddress> writeToHashSet;
-				TileTypeAssignments.TryGetValue(tileType, out writeToHashSet);
+				TileTypeAssignments.TryGetValue(tileType.Name, out writeToHashSet);
 				writeToHashSet.Add(tileAddress);
 			}
 		}
@@ -120,7 +120,7 @@ public partial class GridRenderer : Node
 														"," + y.ToString() + "]");
 				}
 				
-				currentTilesAvailable = TileTypeAssignments[currentTileType];
+				currentTilesAvailable = TileTypeAssignments[currentTileType.Name];
 				if (currentTilesAvailable == null)
 				{
 					throw new InvalidOperationException("Invalid TileType on Type property of Grid Cell [" + x.ToString() + "," + y.ToString() + "]");

--- a/Roguelike.csproj
+++ b/Roguelike.csproj
@@ -5,4 +5,7 @@
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'ios' ">net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="Map\Render\" />
+  </ItemGroup>
 </Project>

--- a/main.tscn
+++ b/main.tscn
@@ -17,12 +17,12 @@ ActiveTileMap = NodePath("../TileMap")
 SourceTileSet = ExtResource("2_wjtum")
 GeneratedMapWidth = 100
 GeneratedMapHeight = 100
-MapGeneratorSequence = [NodePath("BSP Generator")]
+MapGeneratorSequence = [NodePath("BSP Generator"), NodePath("CA Generator")]
 TileAssociationsPath = "res://Asset/TileTypeAssociation/simple-tile-association.json"
 
 [node name="CA Generator" type="Node" parent="Map Builder"]
 script = ExtResource("3_1c22k")
-LifeCycles = 25
+LifeCycles = 1
 CycleEmissionDelay = 0.1
 
 [node name="BSP Generator" type="Node" parent="Map Builder"]

--- a/main.tscn
+++ b/main.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://bd8l36w4uxr48"]
+[gd_scene load_steps=5 format=3 uid="uid://bd8l36w4uxr48"]
 
 [ext_resource type="Script" path="res://Map/ProceduralMapBuilder.cs" id="1_os0gb"]
 [ext_resource type="TileSet" uid="uid://bb5dug3f8yq6k" path="res://Map/TileSet/Dungeon A.tres" id="2_wjtum"]
+[ext_resource type="Script" path="res://Map/Generator/CellularAutomataMapGenerator.cs" id="3_1c22k"]
 [ext_resource type="Script" path="res://Map/Generator/Room/BinarySpacePartitionGenerator.cs" id="3_4tfxg"]
 
 [node name="Main" type="Node"]
@@ -10,17 +11,23 @@
 scale = Vector2(0.1, 0.1)
 format = 2
 
-[node name="Map Builder" type="Node" parent="." node_paths=PackedStringArray("ActiveTileMap", "ActiveMapGenerator")]
+[node name="Map Builder" type="Node" parent="." node_paths=PackedStringArray("ActiveTileMap", "MapGeneratorSequence")]
 script = ExtResource("1_os0gb")
 ActiveTileMap = NodePath("../TileMap")
 SourceTileSet = ExtResource("2_wjtum")
-ActiveMapGenerator = NodePath("../Map Generator")
+GeneratedMapWidth = 100
+GeneratedMapHeight = 100
+MapGeneratorSequence = [NodePath("BSP Generator")]
 TileAssociationsPath = "res://Asset/TileTypeAssociation/simple-tile-association.json"
 
-[node name="Map Generator" type="Node" parent="."]
+[node name="CA Generator" type="Node" parent="Map Builder"]
+script = ExtResource("3_1c22k")
+LifeCycles = 25
+CycleEmissionDelay = 0.1
+
+[node name="BSP Generator" type="Node" parent="Map Builder"]
 script = ExtResource("3_4tfxg")
-DivisionDepth = 10
+DivisionDepth = 5
 MinConnectionsPerRoom = 3
 MaxConnectionsPerRoom = 5
-Width = 300
-Height = 225
+CycleEmissionDelay = 0.1


### PR DESCRIPTION
The reality of the implementation cut back on the requirements a bit.  

* The JSON tiletype association will continue to work as it did before.  Every tile type referenced in the TileMap must be tied to tiles in the TileMap.
* There is no need to have an explicit switch indicating whether or not the map is being initialized or modified.  The responsibility for tracking the Grid Map has been shifted to the Procedural Map Generator which initializes a single map then moves it through the list.  This means that   
(1) The first thing we do is initialize the map   
(2) Every MapGenerator is modifying the exiting map.  No initialization is taking place.

Other than these changes, things went more or less according to plan.  Wit this Update 

* Builder will assign Grid to MapGenerator instances as they are invoked.
* Compartmentalizes Connection and Disconnection activities between ProcedrualMapBuilder and MapGenerator Instances.
* Moves concern of Grid management (not manipulation) to ProceduralMapBuilder.
* Puts burden of map configuration on ProceduralMapBuilder.
* Hides the ActiveMapBuilder from the UI (though it remains as private) and exposes an array (MapG   
eneratorSequence) which will hold the generators to be used for processing, in sequence.
* Removes Self-Driven-on-ready behaviors from MapGenerator and changes language a bit so that the Begin() method should be invoked on a MapGenerator to kick off the process instead.
*  Tracks tile and tiletype associations by string instead of TileType so that different implementations of the same tile type don't confound or conflict.